### PR TITLE
feat(config): #EVAL-85 add optional option config while saving pdf

### DIFF
--- a/helpers/generatePdf.js
+++ b/helpers/generatePdf.js
@@ -11,7 +11,8 @@ const generatePdf = async (template, token, basic, cookie) => {
     }
     const content = fs.readFileSync(template, 'utf-8');
     await page.setContent(content);
-    const buffer = await page.pdf({
+    const config = await page.evaluate(() => window.pdfGeneratorConfig || {});
+    const options = {
         format: 'A4',
         printBackground: true,
         margin: {
@@ -20,7 +21,8 @@ const generatePdf = async (template, token, basic, cookie) => {
             right: '0px',
             bottom: '0px'
         }
-    });
+    };
+    const buffer = await page.pdf(!Object.keys(config).length ? options : config);
     await browser.close();
     return buffer;
 }


### PR DESCRIPTION
Pour le ticket de Compétences (#EVAL-85), nous avons besoin de rajouter de la pagination pour nos générations de PDF (node-pdf-generator)

Or, en utilisant des paramètres customisés pour le besoin de compétences, on risque de créer des comportements non voulu pour la génération du pdf (problème de margin etc...)

Afin de "dynamiser" nos paramètres `option` pour la méthode `page.pdf(option = {}`, on rajoute une possibilité de rajouter un objet `window.pdfGenerator` dans le template qu'on veut utiliser pour générer notre PDF.

Une vérification est faite pour utiliser l'objet ou l'option mis par défaut.

Exemple cas utilisation :

```
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
...
<head>
    <script type="text/javascript">
        window.pdfGeneratorConfig = {
            displayHeaderFooter: true,
            footerTemplate: `
              &lt;div style="font-size: 10px; padding-top: 5px; text-align: right; width: 100%;">
                &lt;span class="pageNumber">&lt;/span> / &lt;span class="totalPages ">&lt;/span>
              &lt;/div>
            `,
            format: 'A4',
            margin: {
                left: '0px',
                top: '0px',
                right: '0px',
                bottom: '0px'
            },
            printBackground: true,
        }
    </script>
...
</html>
```