### PR TITLE
Ajout d'une whitelist pour la génération de pdf

### DIFF
--- a/commons/pageWithInterceptor.js
+++ b/commons/pageWithInterceptor.js
@@ -1,0 +1,48 @@
+const config = require('../conf/config.json');
+const domainWhitelist = config.domainWhitelist;
+const cacheDomain = []
+/**
+ *
+ * @param {*} page intercept request for this page and check if request is in whitelist domain
+ */
+async function pageWithInterceptor(page) {
+  console.log("[Interceptor] enable interceptor")
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    // accept data protocol
+    if(url.protocol==="data:"){
+      request.continue();
+      return;
+    }
+    // check in cache
+    if(cacheDomain.includes(url.hostname)){
+      request.continue();
+      return;
+    }
+    // check by domain without regex
+    if(domainWhitelist.includes(url.hostname)){
+      cacheDomain.push(url.hostname)
+      request.continue();
+      return;
+    }
+    // check by domain with wildcard
+    const isWhitelisted = domainWhitelist.some(domain => {
+      if(domain.startsWith("*.")){
+        const domainSuffix = domain.replace("*","");
+        return url.hostname.endsWith(domainSuffix);
+      }
+      return false;
+    });
+    if (isWhitelisted) {
+      cacheDomain.push(url.hostname)
+      request.continue();
+    } else {
+      console.warn("[Interceptor] abort query:", request.url())
+      request.abort();
+    }
+  });
+  return page;
+}
+
+module.exports = {pageWithInterceptor}

--- a/conf/config.json
+++ b/conf/config.json
@@ -1,3 +1,7 @@
 {
-    "auth" : "ZXhwb3J0cGRmOnNlY3JldA=="
+    "auth": "ZXhwb3J0cGRmOnNlY3JldA==",
+    "domainWhitelist": [
+        "opendigitaleducation.com",
+        "*.opendigitaleducation.com"
+    ]
 }

--- a/helpers/generatePdf.js
+++ b/helpers/generatePdf.js
@@ -1,9 +1,10 @@
 const puppeteer = require("puppeteer");
 const fs = require("fs");
+const { pageWithInterceptor } = require("../commons/pageWithInterceptor");
 
 const generatePdf = async (template, token, basic, cookie) => {
     const browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
-    const page = await browser.newPage();
+    const page = await pageWithInterceptor(await browser.newPage());
     if (token && basic) {
         await page.setExtraHTTPHeaders({ Authorization: "Basic " + basic + ", Bearer " + token });
     } else if (cookie) {

--- a/helpers/printPdf.js
+++ b/helpers/printPdf.js
@@ -1,8 +1,9 @@
 const puppeteer = require("puppeteer");
+const { pageWithInterceptor } = require("../commons/pageWithInterceptor");
 
 const printPdf = async (url, token, basic, cookie) => {
     const browser = await puppeteer.launch({ args: ['--disable-web-security', "--no-sandbox", "--disable-setuid-sandbox"] });
-    const page = await browser.newPage();
+    const page = await pageWithInterceptor(await browser.newPage());
     if (token && basic) {
         await page.setExtraHTTPHeaders({ Authorization: "Basic " + basic + ", Bearer " + token });
     } else if (cookie) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-pdf-generator",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "scripts": {
     "start": "npm install && node app.js"
   },


### PR DESCRIPTION
# Description

Ce commit permet de configurer une liste de domaine autorisées lors de la génération du PDF

> Il faudrait limiter les ressources pour la construction des pdf aux uri de l'ent. Mais, ça pourrait poser problème si des uri externes sont utilisé dans les ressources.

## Ticket

Ticket JIRA : [WB2-531](https://opendigitaleducation.atlassian.net/browse/WB2-531)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Tests

Testé avec postman sur le  node-pdf: https://next-pdf.int.opendigitaleducation.com/print/pdf
Avec un blog contenant des dizaines d'images.
Résultat:
- les images "data" => affichage ok
- les images pointant vers un domaine ENT whitelist => affichage ok
- les ressources pointant vers des domaines externes whitelist (edumedia, google font) => affichage ok
- les ressources pointant vers des domaines non whitelist => affichage nok

Le détail du test est dans le ticket

# Reminder

Une nouvelle config est dispo (le détail est dans le ticket : https://opendigitaleducation.atlassian.net/browse/WB2-865)

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:


[WB2-531]: https://opendigitaleducation.atlassian.net/browse/WB2-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ